### PR TITLE
chore: dispatch operation sending int instead str

### DIFF
--- a/includes/push_swap.h
+++ b/includes/push_swap.h
@@ -6,7 +6,7 @@
 /*   By: gmasid <gmasid@student.42.rio>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/13 17:13:18 by gmasid            #+#    #+#             */
-/*   Updated: 2022/09/03 19:46:43 by gmasid           ###   ########.fr       */
+/*   Updated: 2022/09/04 15:04:48 by gmasid           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,12 +24,27 @@ typedef struct s_stack
 	int	*array;
 }		t_stack;
 
+enum	e_operations
+{
+	SA = 11,
+	SB = 12,
+	SS = 13,
+	RA = 21,
+	RB = 22,
+	RR = 23,
+	PA = 31,
+	PB = 32,
+	RRA = 41,
+	RRB = 42,
+	RRR = 43
+};
+
 t_stack	*create_stack(unsigned int size);
 void	free_stacks(t_stack *stack_a, t_stack *stack_b);
 
 int		throw_error(char *error);
 int		fill_stack(t_stack *stack, int ac, char **av);
-int		dispatch_operation(char *operation, t_stack *stack_a, t_stack *stack_b);
+int		dispatch_operation(int operation, t_stack *stack_a, t_stack *stack_b);
 
 int		swap(t_stack *stack);
 int		rotate(t_stack *stack);

--- a/src/push_swap.c
+++ b/src/push_swap.c
@@ -6,7 +6,7 @@
 /*   By: gmasid <gmasid@student.42.rio>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/26 14:04:20 by gmasid            #+#    #+#             */
-/*   Updated: 2022/09/03 19:46:13 by gmasid           ###   ########.fr       */
+/*   Updated: 2022/09/04 15:07:25 by gmasid           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,21 @@ int	main(int argc, char **argv)
 	stack_b = create_stack(argc - 1);
 	if (!fill_stack(stack_a, argc - 1, argv + 1))
 		return (throw_error("You provide a invalid or duplicate number"));
+	ft_printf("----------- BEFORE ----------\n");
+	ft_printf("STACK A\n");
+	print_list(stack_a);
+	ft_printf("\n\n");
+	ft_printf("STACK B\n");
+	print_list(stack_b);
+	// ---
+	dispatch_operation(RRA, stack_a, stack_b);
+	// ---
+	ft_printf("\n\n\n----------- AFTER ------------\n");
+	ft_printf("STACK A\n");
+	print_list(stack_a);
+	ft_printf("\n\n");
+	ft_printf("STACK B\n");
+	print_list(stack_b);
 	free_stacks(stack_a, stack_b);
 	return (0);
 }

--- a/src/stack/operations_controller.c
+++ b/src/stack/operations_controller.c
@@ -6,44 +6,71 @@
 /*   By: gmasid <gmasid@student.42.rio>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/03 16:28:22 by gmasid            #+#    #+#             */
-/*   Updated: 2022/09/03 16:45:13 by gmasid           ###   ########.fr       */
+/*   Updated: 2022/09/04 16:01:07 by gmasid           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/push_swap.h"
 
-int	execute_operation(char *operation, t_stack *stack_a, t_stack *stack_b)
+char	*get_operation_str(int operation)
 {
-	if (ft_strncmp(operation, "sa", 2) == 0)
+	if (operation == SA)
+		return ("sa");
+	if (operation == SB)
+		return ("sb");
+	if (operation == SS)
+		return ("ss");
+	if (operation == RRA)
+		return ("rra");
+	if (operation == RRB)
+		return ("rrb");
+	if (operation == RRR)
+		return ("rrr");
+	if (operation == RA)
+		return ("ra");
+	if (operation == RB)
+		return ("rb");
+	if (operation == RR)
+		return ("rr");
+	if (operation == PA)
+		return ("pa");
+	if (operation == PB)
+		return ("pb");
+	return ("");
+}
+
+int	execute_operation(int operation, t_stack *stack_a, t_stack *stack_b)
+{
+	if (operation == SA)
 		return (swap(stack_a));
-	if (ft_strncmp(operation, "sb", 2) == 0)
+	if (operation == SB)
 		return (swap(stack_b));
-	if (ft_strncmp(operation, "ss", 2) == 0)
+	if (operation == SS)
 		return (swap(stack_a) && swap(stack_b));
-	if (ft_strncmp(operation, "rra", 3) == 0)
+	if (operation == RRA)
 		return (reverse_rotate(stack_a));
-	if (ft_strncmp(operation, "rrb", 3) == 0)
+	if (operation == RRB)
 		return (reverse_rotate(stack_b));
-	if (ft_strncmp(operation, "rrr", 3) == 0)
+	if (operation == RRR)
 		return (reverse_rotate(stack_a) && reverse_rotate(stack_b));
-	if (ft_strncmp(operation, "ra", 2) == 0)
+	if (operation == RA)
 		return (rotate(stack_a));
-	if (ft_strncmp(operation, "rb", 2) == 0)
+	if (operation == RB)
 		return (rotate(stack_b));
-	if (ft_strncmp(operation, "rr", 2) == 0)
+	if (operation == RR)
 		return (rotate(stack_a) && rotate(stack_b));
-	if (ft_strncmp(operation, "pa", 2) == 0)
+	if (operation == PA)
 		return (push_from(stack_b, stack_a));
-	if (ft_strncmp(operation, "pb", 2) == 0)
+	if (operation == PB)
 		return (push_from(stack_a, stack_b));
 	return (0);
 }
 
-int	dispatch_operation(char *operation, t_stack *stack_a, t_stack *stack_b)
+int	dispatch_operation(int operation, t_stack *stack_a, t_stack *stack_b)
 {
 	if (execute_operation(operation, stack_a, stack_b))
 	{
-		ft_printf("%s\n", operation);
+		ft_printf("%s\n", get_operation_str(operation));
 		return (1);
 	}
 	return (0);


### PR DESCRIPTION
# Dispatch operation sending int instead str

### Instead send operations like this

```
dispatch_operation("rra", stack_a, stack_b);
```

### We send like this:

```
dispatch_operation(RRA, stack_a, stack_b);
```

### Obs: all available operations are listed in `includes/push_swap.h`

```
enum	e_operations
{
	SA = 11,
	SB = 12,
	SS = 13,
	RA = 21,
	RB = 22,
	RR = 23,
	PA = 31,
	PB = 32,
	RRA = 41,
	RRB = 42,
	RRR = 43
};
```